### PR TITLE
Fix: imgui examples moving to backends

### DIFF
--- a/imgui/CMakeLists.txt
+++ b/imgui/CMakeLists.txt
@@ -27,7 +27,7 @@ if(glfw3_FOUND AND OPENGL_FOUND AND glew_FOUND)
     message(STATUS "OpenGL, GLEW and GLFW found, installing imgui::glfw-gl3-glew.")
 
     # replace #include gl3w.h with glew.h
-    file(STRINGS examples/opengl3_example/imgui_impl_glfw_gl3.cpp cppcontent)
+    file(STRINGS examples/example_glfw_opengl3/main.cpp cppcontent)
     set(cppcontent-glew "")
     foreach(l ${cppcontent})
         if(l MATCHES "#include.*GL/gl3w.h")
@@ -40,14 +40,19 @@ if(glfw3_FOUND AND OPENGL_FOUND AND glew_FOUND)
 
     add_library(glfw-gl3-glew STATIC
         "${modified_cpp}"
-        examples/opengl3_example/imgui_impl_glfw_gl3.h
+        backends/imgui_impl_opengl3.h
+    )
+    add_library(glfw-gl3-glew STATIC
+        "${modified_cpp}"
+        backends/imgui_impl_glfw.h
     )
     target_include_directories(glfw-gl3-glew PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/examples/opengl3_example>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/backends>
         $<INSTALL_INTERFACE:include>)
     target_link_libraries(glfw-gl3-glew PUBLIC OpenGL::GL GLEW::glew_s glfw imgui)
     list(APPEND targets glfw-gl3-glew)
-    list(APPEND headers_to_install examples/opengl3_example/imgui_impl_glfw_gl3.h)
+    list(APPEND headers_to_install backends/imgui_impl_opengl3.h)
+    list(APPEND headers_to_install backends/imgui_impl_glfw.h)
 else()
     if(NOT OPENGL_FOUND)
         message(STATUS "OpenGL not found, not installing imgui::glfw-gl3-glew.")

--- a/imgui/CMakeLists.txt
+++ b/imgui/CMakeLists.txt
@@ -41,9 +41,6 @@ if(glfw3_FOUND AND OPENGL_FOUND AND glew_FOUND)
     add_library(glfw-gl3-glew STATIC
         "${modified_cpp}"
         backends/imgui_impl_opengl3.h
-    )
-    add_library(glfw-gl3-glew STATIC
-        "${modified_cpp}"
         backends/imgui_impl_glfw.h
     )
     target_include_directories(glfw-gl3-glew PUBLIC


### PR DESCRIPTION
imgui extracted backends from examples/ into backends/

https://github.com/ocornut/imgui/commit/b1a18d82e32f13a2ae62df70d08ee46bc8ee6a76

This error is in cmakefied/imgui/CMakeLists.txt at line 30 and a few more places.

file(STRINGS examples/opengl3_example/imgui_impl_glfw_gl3.cpp cppcontent)